### PR TITLE
Support other audio sample rates

### DIFF
--- a/index.js
+++ b/index.js
@@ -286,18 +286,10 @@ class GamebuinoEmulator extends HTMLElement {
 
     initAudio() {
         const AudioContext = window.AudioContext || window.webkitAudioContext;
-        if (AudioContext && !this.audioCtx || this.audioCtx.sampleRate != this.gamebuino.sample_rate) {
-            console.log("Sample rate = ", this.gamebuino.sample_rate);
-            if (this.audioCtx) {
-                console.log("Changing audio context");
-                this.audioCtx.close();
-            }
+        if (!this.audioCtx && AudioContext) {
+            console.log("Audio sample rate = ", this.gamebuino.sample_rate);
             this.audioCtx = new AudioContext({ sampleRate: this.gamebuino.sample_rate });
             this.audioCtx.resume();
-
-            this.totalSamples = 0;
-            this.audioStart = undefined;
-            this.lastLog = Date.now();
         }
     }
 
@@ -309,19 +301,6 @@ class GamebuinoEmulator extends HTMLElement {
         const audioBuffer = this.audioCtx.createBuffer(1, frameCount, this.audioCtx.sampleRate);
         const channelBuffer = audioBuffer.getChannelData(0);
         const source = this.audioCtx.createBufferSource();
-
-        const now = Date.now();
-        const delta = now - this.lastLog;
-        if (delta > 1000) {
-            if (!this.audioStart) {
-                this.audioStart = now;
-                this.totalSamples = 0;
-            } else {
-                console.log("sample rate [kHz]= ", this.totalSamples / (now - this.audioStart));
-            }
-            this.lastLog = now;
-        }
-        this.totalSamples += frameCount;
 
         for (let i = 0; i < frameCount; i++) {
             channelBuffer[i] = raw[i] / 1024;

--- a/src/register.rs
+++ b/src/register.rs
@@ -267,3 +267,11 @@ impl Peripheral for SercomRegisters {
         }
     }
 }
+
+pub struct TcRegisters {
+}
+
+impl TcRegisters {
+    const TC5_ADDRESS: u32 = 0x42003400;
+    pub const TC5_CC_ADDRESS: u32 = TcRegisters::TC5_ADDRESS + 0x18;
+}


### PR DESCRIPTION
The current audio support assumes a sampling rate of 44.1 kHz. Some of my creations use a different (lower) sampling rate, so I wanted to get that to work as well.

This set of changes achieves that. You can, for example, try this out on the following:
https://github.com/erwinbonsma/MusicDemoGB/raw/master/Binaries/MusicDemo.bin
https://github.com/erwinbonsma/RoboRePairGB/raw/master/Binaries/BumbleBotsRePair/BumbleBotsRePair.bin

You may find that the second creation can panic. This, however, is not specific to these changes. I can also reproduce that with the latest released binary (version 0.6.0). I do not yet know what is wrong there and will submit a separate issue for that.

Note, due to integer division inaccuracies, the emulator code does not exactly reproduce the original sampling rate. For example, a sampling rate of 44100 becomes 44117. This small difference appears to be insignificant so I did not compensate for it. The only place where I could image it being relevant is if the JavaScript AudioContext only supports a discrete number of sampling frequencies, but that does not seem to be the case.